### PR TITLE
ci: setup multiarch docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,18 @@ jobs:
           extra_args: --debug --only-verified
 
   ci:
-    name: CI
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    name: CI / ${{ matrix.arch.arch }}
+    runs-on: ${{ matrix.arch.runs-on }}
+    timeout-minutes: 20
     container: golang:1.24
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - runs-on: ubuntu-24.04
+            arch: amd64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,6 +69,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -94,3 +105,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,10 +23,18 @@ jobs:
           extra_args: --debug --only-verified
 
   ci:
-    name: CI
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    name: CI / ${{ matrix.arch.arch }}
+    runs-on: ${{ matrix.arch.runs-on }}
+    timeout-minutes: 20
     container: golang:1.24
+    strategy:
+      fail-fast: true
+      matrix:
+        arch:
+          - runs-on: ubuntu-24.04
+            arch: amd64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -51,5 +54,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Provide arm64 image for Docker. Since arm64 machines are getting more mainstream, we should support those.